### PR TITLE
🔧 Added custom rule to disable automerges for pre-release patch bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,9 +36,9 @@
 	],
 	"packageRules": [
 		{
-        	"description": "Disable automerge for patch-level updates when pre-release version",
+			"description": "Disable automerge for patch-level updates when pre-release version",
         	"matchUpdateTypes": ["patch"],
-			"matchCurrentVersion": "/^0\\./"
+			"matchCurrentVersion": "/^0\\./",
         	"automerge": false
 		},
 	]

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,5 +33,13 @@
 
 		// Security presets (https://docs.renovatebot.com/presets-security/)
 		"security:openssf-scorecard" // show OpenSSF badge on pull requests to evaluate security health metrics for dependencies
+	],
+	"packageRules": [
+		{
+        	"description": "Disable automerge for patch-level updates when pre-release version",
+        	"matchUpdateTypes": ["patch"],
+			"matchCurrentVersion": "/^0\\./"
+        	"automerge": false
+		},
 	]
 }


### PR DESCRIPTION
# Changes
- Adjusted Renovate configuration to not automerge patch release if those a pre-release (0.x.x) bumps