### PR TITLE
:heavy_minus_sign: Remove @types/chrome from devDependencies

### DIFF
--- a/browser-extension/bun.lock
+++ b/browser-extension/bun.lock
@@ -12,7 +12,6 @@
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "4.4.1",
         "@mdi/js": "7.4.47",
-        "@types/chrome": "0.0.315",
         "@vitest/coverage-v8": "3.1.2",
         "@vue/eslint-config-prettier": "10.2.0",
         "@vue/eslint-config-typescript": "14.5.0",
@@ -265,8 +264,6 @@
     "@sindresorhus/is": ["@sindresorhus/is@5.6.0", "", {}, "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@5.0.1", "", { "dependencies": { "defer-to-connect": "^2.0.1" } }, "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw=="],
-
-    "@types/chrome": ["@types/chrome@0.0.315", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-Oy1dYWkr6BCmgwBtOngLByCHstQ3whltZg7/7lubgIZEYvKobDneqplgc6LKERNRBwckFviV4UU5AZZNUFrJ4A=="],
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "4.4.1",
     "@mdi/js": "7.4.47",
-    "@types/chrome": "0.0.315",
     "@vitest/coverage-v8": "3.1.2",
     "@vue/eslint-config-prettier": "10.2.0",
     "@vue/eslint-config-typescript": "14.5.0",


### PR DESCRIPTION
# Changes
- Removed `@types/chrome` as typings for chrome are no longer required due to WXT's own abstraction