### PR TITLE
Fix: Env loading for metrics calculation now works as expected

### DIFF
--- a/evaluation/src/04_calculate_metrics.py
+++ b/evaluation/src/04_calculate_metrics.py
@@ -1,7 +1,13 @@
+from utility import (
+  ConfigurationService,
+  KeyboardInterruptError,
+  LoggingService,
+)
+
+ConfigurationService.load_environment_configuration()
 from calculation import CalculationService
 from metric import MetricService
 from model import ModelService
-from utility import KeyboardInterruptError, LoggingService
 
 
 def calculate_metrics():

--- a/evaluation/src/calculation/calculation_service.py
+++ b/evaluation/src/calculation/calculation_service.py
@@ -118,7 +118,7 @@ class CalculationService:
       try:
         return FileService.from_csv_to_string_list(filepath)
       except Exception as exc:
-        raise CalculationPredictionsFileNotFoundError(f"The references file '{filename}' does not exist.") from exc
+        raise CalculationPredictionsFileNotFoundError(f"The predictions file '{filename}' does not exist.") from exc
 
     @staticmethod
     def _calculate_no_references(texts: List[str], func: Callable, metric: Metric) -> float:


### PR DESCRIPTION
# Changes
- Fixed a bug where calculation script was using global cache instead of the optional local configured cache