### PR TITLE
Maintenance: Downgrade to Python 3.13.6 and disable automerge

### DIFF
--- a/evaluation/pyproject.toml
+++ b/evaluation/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 repository = "https://github.com/devtobi/aigelb"
 readme = "README.md"
 keywords = [ "llm", "evaluation", "metrics", "nlp", "mt", "easylanguage" ]
-requires-python = "==3.13.7"
+requires-python = "==3.13.6"
 dependencies = [
     "dotenv (==0.9.9)",
     "huggingface_hub (==0.34.4)",

--- a/evaluation/uv.lock
+++ b/evaluation/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.13.7"
+requires-python = "==3.13.6"
 
 [[package]]
 name = "aiohappyeyeballs"

--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,12 @@
             "matchUpdateTypes": ["patch"],
 			"matchCurrentVersion": "/^0\\./",
             "automerge": false
+		},
+		{
+			"description": "Disable automerge for python version",
+			"matchManagers": ["pep621"],
+			"matchPackageNames": ["python"],
+			"automerge": false
 		}
 	],
 	"lockFileMaintenance": {


### PR DESCRIPTION
# Changes
- Downgraded to Python 3.13.6
- Disabled automerge in Renovate configuration (for python only)