### PR TITLE
Maintenance: Added close protection when onboarding not completed

### DIFF
--- a/browser-extension/.prettierrc.json
+++ b/browser-extension/.prettierrc.json
@@ -30,6 +30,6 @@
     "^@(/.*)$",
     "^[.]"
   ],
-  "importOrderTypeScriptVersion": "5.8.2",
+  "importOrderTypeScriptVersion": "5.9.2",
   "importOrderParserPlugins": ["typescript"]
 }

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -2,7 +2,7 @@
   "name": "aigelb-browser-extension",
   "description": "AI-based browser extension to read the web in German Easy Language (Leichte Sprache) using the power of local AI models",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev:chrome": "concurrently --kill-others-on-fail bun:webserver \"wxt -b chrome\"",

--- a/browser-extension/src/components/instructions/CloseDialog.vue
+++ b/browser-extension/src/components/instructions/CloseDialog.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-dialog
+    :model-value="show"
+    persistent
+    max-width="400"
+  >
+    <v-card
+      :title="i18n.t('instructions.closeDialog.title')"
+      class="pa-3"
+    >
+      <v-card-text class="text-body-2">
+        {{ i18n.t("instructions.closeDialog.description") }}
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          :text="i18n.t('common.cancel')"
+          @click="emit('cancel')"
+        />
+        <v-btn
+          :text="i18n.t('common.close')"
+          @click="emit('close')"
+          color="warning"
+        />
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { i18n } from "#i18n";
+
+defineProps<{
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  cancel: [];
+}>();
+</script>

--- a/browser-extension/src/components/instructions/SetupCard.vue
+++ b/browser-extension/src/components/instructions/SetupCard.vue
@@ -280,7 +280,7 @@ const modelStepTitle = computed(() => {
 watch(
   [isOllamaAvailable, isModelAvailable],
   ([ollama, model]) => {
-    emit("onboarding-completed-changed", !!ollama && !!model);
+    emit("onboardingCompletedChanged", !!ollama && !!model);
   },
   { immediate: true }
 );

--- a/browser-extension/src/components/instructions/SetupCard.vue
+++ b/browser-extension/src/components/instructions/SetupCard.vue
@@ -168,6 +168,10 @@ import { LLM_HUGGINGFACE_FILE, LLM_HUGGINGFACE_REPO } from "@/config.ts";
 import { convertToOllamaUrl } from "@/utility/conversion.ts";
 import { sendMessage } from "@/utility/messaging.ts";
 
+const emit = defineEmits<{
+  onboardingCompletedChanged: [value: boolean];
+}>();
+
 // Stepper setup
 onMounted(async () => {
   browser.action.onUserSettingsChanged?.addListener(updatePinStatus);
@@ -272,6 +276,14 @@ const modelStepTitle = computed(() => {
   }
   return `${i18n.t("instructions.setupCard.modelStep.title")}${suffix}`;
 });
+
+watch(
+  [isOllamaAvailable, isModelAvailable],
+  ([ollama, model]) => {
+    emit("onboarding-completed-changed", !!ollama && !!model);
+  },
+  { immediate: true }
+);
 
 // Pin check
 const { isPinnedInToolbar } = useBrowser();

--- a/browser-extension/src/entrypoints/instructions/App.vue
+++ b/browser-extension/src/entrypoints/instructions/App.vue
@@ -12,7 +12,10 @@
         <header-card class="mb-8" />
         <about-card class="mb-8" />
         <important-notes-card class="mb-8" />
-        <setup-card class="mb-8" />
+        <setup-card
+          class="mb-8"
+          @onboarding-completed-changed="onOnboardingCompletedChanged"
+        />
         <links-panel class="mb-8" />
         <close-button @close="onClickClose" />
       </v-container>
@@ -38,6 +41,10 @@ const { closeWindow } = useBrowser();
 const showDialog = ref(false);
 
 const isOnboardingCompleted = ref(false);
+
+function onOnboardingCompletedChanged(value: boolean) {
+  isOnboardingCompleted.value = value;
+}
 
 function onClickClose() {
   if (!isOnboardingCompleted.value) {

--- a/browser-extension/src/entrypoints/instructions/App.vue
+++ b/browser-extension/src/entrypoints/instructions/App.vue
@@ -1,5 +1,10 @@
 <template>
   <v-app>
+    <close-dialog
+      :show="showDialog"
+      @close="confirmedClose"
+      @cancel="cancelClose"
+    />
     <the-app-bar />
 
     <v-main>
@@ -9,16 +14,19 @@
         <important-notes-card class="mb-8" />
         <setup-card class="mb-8" />
         <links-panel class="mb-8" />
-        <close-button @close="closeWindow" />
+        <close-button @close="onClickClose" />
       </v-container>
     </v-main>
   </v-app>
 </template>
 
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
 import TheAppBar from "@/components/common/TheAppBar.vue";
 import AboutCard from "@/components/instructions/AboutCard.vue";
 import CloseButton from "@/components/instructions/CloseButton.vue";
+import CloseDialog from "@/components/instructions/CloseDialog.vue";
 import HeaderCard from "@/components/instructions/HeaderCard.vue";
 import ImportantNotesCard from "@/components/instructions/ImportantNotesCard.vue";
 import LinksPanel from "@/components/instructions/LinksPanel.vue";
@@ -26,4 +34,52 @@ import SetupCard from "@/components/instructions/SetupCard.vue";
 import { useBrowser } from "@/composables/useBrowser.ts";
 
 const { closeWindow } = useBrowser();
+
+const showDialog = ref(false);
+
+const isOnboardingCompleted = ref(false);
+
+function onClickClose() {
+  if (!isOnboardingCompleted.value) {
+    showDialog.value = true;
+  } else {
+    closeWindow();
+  }
+}
+
+function confirmedClose() {
+  showDialog.value = false;
+  removeBeforeUnload();
+  closeWindow();
+}
+
+function cancelClose() {
+  showDialog.value = false;
+}
+
+function beforeUnloadHandler(event: BeforeUnloadEvent) {
+  if (!isOnboardingCompleted.value) {
+    event.preventDefault();
+  } else {
+    removeBeforeUnload();
+  }
+}
+
+function removeBeforeUnload() {
+  window.removeEventListener("beforeunload", beforeUnloadHandler);
+}
+
+onMounted(() => {
+  window.addEventListener(
+    "click",
+    () => {
+      window.addEventListener("beforeunload", beforeUnloadHandler);
+    },
+    { once: true }
+  );
+});
+
+onBeforeUnmount(() => {
+  removeBeforeUnload()
+});
 </script>

--- a/browser-extension/src/entrypoints/instructions/App.vue
+++ b/browser-extension/src/entrypoints/instructions/App.vue
@@ -80,6 +80,6 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  removeBeforeUnload()
+  removeBeforeUnload();
 });
 </script>

--- a/browser-extension/src/locales/de.yml
+++ b/browser-extension/src/locales/de.yml
@@ -7,6 +7,8 @@ common:
   next: Weiter
   optional: optional
   skip: Überspringen
+  cancel: Abbrechen
+  close: Schließen
 instructions:
   headerCard:
     subTitle: AI German Easy Language Browsing (KI-gestütztes Browsen in deutscher Leichter Sprache)
@@ -20,7 +22,7 @@ instructions:
     description: Die KI-basierte Übersetzung und Vereinfachung von Texten (insbesondere für Leichte Sprache) ist eine komplexe und sensible Aufgabe. Bitte beachten Sie, dass KI-Modelle nicht perfekt sind und Fehler machen können. Daher kann die Erweiterung nicht garantieren, dass der übersetzte oder vereinfachte Text inhaltlich korrekt ist und alle Regeln der Leichten Sprache einhält. Verwenden Sie die Erweiterung mit Vorsicht und lassen Sie die Ergebnisse nach Möglichkeit von einem Menschen überprüfen. Insbesondere bei sensiblen Themen wie medizinischen oder finanziellen Informationen sollte die Erweiterung nicht ohne menschliche Validierung der generierten Inhalte verwendet werden.
     development: AIGELB befindet sich derzeit in der Entwicklungsphase. Einige Übersetzungen sind möglicherweise fehlerhaft oder unvollständig, und die Erweiterung ist möglicherweise noch nicht voll funktionsfähig. Außerdem können Fehler auftreten. Bitte melden Sie alle Probleme im GitHub-Repository des Projekts. Den Link zum Repository finden Sie unten auf dieser Seite.
   setupCard:
-    title: Ersteinrichtung
+    title: Einrichtung
     ollamaStep:
       title: KI-Software installieren und starten
       successSuffix: Verbindung erfolgreich
@@ -56,3 +58,6 @@ instructions:
   closeButton:
     text: Anleitung schließen
     tooltip: Die Anleitung kann jederzeit wieder über das AIGELB-Symbol in der Browserleiste geöffnet werden.
+  closeDialog:
+    title: Einrichtung nicht abgeschlossen
+    description: Die Einrichtung von AIGELB ist noch nicht abgeschlossen. Daher wird die Erweiterung noch nicht funktionieren. Diese Seite kann jederzeit über das AIGELB-Symbol in der Browserleiste wieder geöffnet und die Einrichtung fortgesetzt werden.

--- a/browser-extension/src/locales/en.yml
+++ b/browser-extension/src/locales/en.yml
@@ -7,6 +7,8 @@ common:
   next: Next
   optional: optional
   skip: Skip
+  cancel: Cancel
+  close: Close
 instructions:
   headerCard:
     subTitle: AI German Easy Language Browsing
@@ -20,7 +22,7 @@ instructions:
     description: AI-based translation and simplification of text (especially for Easy Language) is a complex and sensitive task. Please note that AI models are not perfect and may make mistakes. Therefore, the extension can not guarantee that the translated or simplified text is semantically correct and respects all rules of Easy Language. Use the extension with caution and validate the results with a human if possible. Especially for sensitive topics such as medical or financial information, the extension should not be used without a human's supervision of the generated content.
     development: AIGELB is currently in an development stage. Some translations may be experimental or incomplete and the extension may not be fully functional. Additionally, bugs may occur. Please report any issues to the projects GitHub repository. You can find the link to the repository at the bottom of this page.
   setupCard:
-    title: Initial setup
+    title: Setup
     ollamaStep:
       title: Install and launch AI software
       successSuffix: Connection successful
@@ -56,3 +58,6 @@ instructions:
   closeButton:
     text: Close instructions
     tooltip: The instructions can be opened again at any time by clicking on the AIGELB icon in the browser bar.
+  closeDialog:
+    title: Setup not finished
+    description: The setup of AIGELB is not yet complete. Therefore, the extension will not work yet. This page can be reopened at any time via the AIGELB icon in the browser bar and the setup can be continued.


### PR DESCRIPTION
# Changes
- Added closeDialog (and native browser tab close check) when onboarding was not finished.
- Upgraded TypeScript version in prettier configuration

Closes #237